### PR TITLE
Add a function to generate auth string, #18

### DIFF
--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -124,14 +124,14 @@ function generateAuthString(state) {
   var auth = state.auth,
       configuration = state.configuration;
 
-  if (configuration.jwt) {
-    var token = auth.token;
-    return "Bearer ".concat(token);
+  if (configuration.basicAuth) {
+    var user = configuration.user,
+        password = configuration.password;
+    return 'Basic ' + Buffer("".concat(user, ":").concat(password)).toString('base64');
   }
 
-  var user = configuration.user,
-      password = configuration.password;
-  return 'Basic ' + Buffer("".concat(user, ":").concat(password)).toString('base64');
+  var token = auth.token;
+  return "Bearer ".concat(token);
 }
 /**
  * Logs in to Primero.

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -129,9 +129,9 @@ function generateAuthString(state) {
     return "Bearer ".concat(token);
   }
 
-  var username = configuration.username,
+  var user = configuration.user,
       password = configuration.password;
-  return 'Basic ' + Buffer("".concat(username, ":").concat(password)).toString('base64');
+  return 'Basic ' + Buffer("".concat(user, ":").concat(password)).toString('base64');
 }
 /**
  * Logs in to Primero.

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -111,6 +111,29 @@ function execute() {
   };
 }
 /**
+ * Generate an auth string to support multiple types of auth credentials.
+ * @example
+ * generateAuthString(state)
+ * @function
+ * @param {State} state
+ * @returns {string}
+ */
+
+
+function generateAuthString(state) {
+  var auth = state.auth,
+      configuration = state.configuration;
+
+  if (configuration.jwt) {
+    var token = auth.token;
+    return "Bearer ".concat(token);
+  }
+
+  var username = configuration.username,
+      password = configuration.password;
+  return 'Basic ' + Buffer("".concat(username, ":").concat(password)).toString('base64');
+}
+/**
  * Logs in to Primero.
  * @example
  *  login(state)
@@ -191,12 +214,11 @@ function cleanupState(state) {
 function getCases(query, callback) {
   return function (state) {
     var url = state.configuration.url;
-    var token = state.auth.token;
     var params = {
       method: 'GET',
       url: "".concat(url, "/api/v2/cases"),
       headers: {
-        Authorization: "Bearer ".concat(token)
+        Authorization: generateAuthString(state)
       },
       qs: query
     };
@@ -250,12 +272,11 @@ function createCase(params, callback) {
     var _expandReferences = (0, _languageCommon.expandReferences)(params)(state),
         data = _expandReferences.data;
 
-    var token = state.auth.token;
     var requestParams = {
       method: 'POST',
       url: "".concat(url, "/api/v2/cases"),
       headers: {
-        Authorization: "Bearer ".concat(token),
+        Authorization: generateAuthString(state),
         options: {
           successCodes: [200, 201, 202, 203, 204]
         }
@@ -312,12 +333,11 @@ function updateCase(id, params, callback) {
     var _expandReferences2 = (0, _languageCommon.expandReferences)(params)(state),
         data = _expandReferences2.data;
 
-    var token = state.auth.token;
     var requestParams = {
       method: 'PATCH',
       url: "".concat(url, "/api/v2/cases/").concat(id),
       headers: {
-        Authorization: "Bearer ".concat(token)
+        Authorization: generateAuthString(state)
       },
       json: {
         data: data
@@ -371,7 +391,6 @@ function upsertCase(params, callback) {
         _data = _expandReferences3.data,
         externalIds = _expandReferences3.externalIds;
 
-    var token = state.auth.token;
     var qs = {
       remote: true,
       scope: {}
@@ -386,7 +405,7 @@ function upsertCase(params, callback) {
       method: 'GET',
       url: "".concat(url, "/api/v2/cases"),
       headers: {
-        Authorization: "Bearer ".concat(token)
+        Authorization: generateAuthString(state)
       },
       qs: qs
     };
@@ -467,12 +486,11 @@ function upsertCase(params, callback) {
 function getReferrals(recordId, callback) {
   return function (state) {
     var url = state.configuration.url;
-    var token = state.auth.token;
     var params = {
       method: 'GET',
       url: "".concat(url, "/api/v2/cases/").concat(recordId, "/referrals"),
       headers: {
-        Authorization: "Bearer ".concat(token)
+        Authorization: generateAuthString(state)
       }
     };
     return new Promise(function (resolve, reject) {
@@ -521,12 +539,11 @@ function createReferrals(params, callback) {
     var _expandReferences4 = (0, _languageCommon.expandReferences)(params)(state),
         data = _expandReferences4.data;
 
-    var token = state.auth.token;
     var requestParams = {
       method: 'POST',
       url: "".concat(url, "/api/v2/cases/referrals"),
       headers: {
-        Authorization: "Bearer ".concat(token),
+        Authorization: generateAuthString(state),
         options: {
           successCodes: [200, 201, 202, 203, 204]
         }

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -49,8 +49,8 @@ function generateAuthString(state) {
     return `Bearer ${token}`;
   }
 
-  const { username, password } = configuration;
-  return 'Basic ' + Buffer(`${username}:${password}`).toString('base64');
+  const { user, password } = configuration;
+  return 'Basic ' + Buffer(`${user}:${password}`).toString('base64');
 }
 
 /**

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -35,6 +35,25 @@ export function execute(...operations) {
 }
 
 /**
+ * Generate an auth string to support multiple types of auth credentials.
+ * @example
+ * generateAuthString(state)
+ * @function
+ * @param {State} state
+ * @returns {string}
+ */
+function generateAuthString(state) {
+  const { auth, configuration } = state;
+  if (configuration.jwt) {
+    const { token } = auth;
+    return `Bearer ${token}`;
+  }
+
+  const { username, password } = configuration;
+  return 'Basic ' + Buffer(`${username}:${password}`).toString('base64');
+}
+
+/**
  * Logs in to Primero.
  * @example
  *  login(state)
@@ -103,13 +122,12 @@ function cleanupState(state) {
 export function getCases(query, callback) {
   return state => {
     const { url } = state.configuration;
-    const { token } = state.auth;
 
     const params = {
       method: 'GET',
       url: `${url}/api/v2/cases`,
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: generateAuthString(state),
       },
       qs: query,
     };
@@ -164,13 +182,12 @@ export function createCase(params, callback) {
     const { url } = state.configuration;
 
     const { data } = expandReferences(params)(state);
-    const { token } = state.auth;
 
     const requestParams = {
       method: 'POST',
       url: `${url}/api/v2/cases`,
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: generateAuthString(state),
         options: {
           successCodes: [200, 201, 202, 203, 204],
         },
@@ -219,13 +236,12 @@ export function updateCase(id, params, callback) {
   return state => {
     const { url } = state.configuration;
     const { data } = expandReferences(params)(state);
-    const { token } = state.auth;
 
     const requestParams = {
       method: 'PATCH',
       url: `${url}/api/v2/cases/${id}`,
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: generateAuthString(state),
       },
       json: { data: data },
     };
@@ -268,7 +284,6 @@ export function upsertCase(params, callback) {
   return state => {
     const { url } = state.configuration;
     const { data, externalIds } = expandReferences(params)(state);
-    const { token } = state.auth;
 
     var qs = {
       remote: true,
@@ -286,7 +301,7 @@ export function upsertCase(params, callback) {
       method: 'GET',
       url: `${url}/api/v2/cases`,
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: generateAuthString(state),
       },
       qs,
     };
@@ -366,13 +381,12 @@ export function upsertCase(params, callback) {
 export function getReferrals(recordId, callback) {
   return state => {
     const { url } = state.configuration;
-    const { token } = state.auth;
 
     const params = {
       method: 'GET',
       url: `${url}/api/v2/cases/${recordId}/referrals`,
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: generateAuthString(state),
       },
     };
 
@@ -424,13 +438,12 @@ export function createReferrals(params, callback) {
     const { url } = state.configuration;
 
     const { data } = expandReferences(params)(state);
-    const { token } = state.auth;
 
     const requestParams = {
       method: 'POST',
       url: `${url}/api/v2/cases/referrals`,
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: generateAuthString(state),
         options: {
           successCodes: [200, 201, 202, 203, 204],
         },

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -44,13 +44,12 @@ export function execute(...operations) {
  */
 function generateAuthString(state) {
   const { auth, configuration } = state;
-  if (configuration.jwt) {
-    const { token } = auth;
-    return `Bearer ${token}`;
+  if (configuration.basicAuth) {
+    const { user, password } = configuration;
+    return 'Basic ' + Buffer(`${user}:${password}`).toString('base64');
   }
-
-  const { user, password } = configuration;
-  return 'Basic ' + Buffer(`${user}:${password}`).toString('base64');
+  const { token } = auth;
+  return `Bearer ${token}`;
 }
 
 /**


### PR DESCRIPTION
```
function generateAuthString(state) {
  const { auth, configuration } = state;
  if (configuration.jwt) {
    const { token } = auth;
    return `Bearer ${token}`;
  }

  const { username, password } = configuration;
  return 'Basic ' + Buffer(`${username}:${password}`).toString('base64');
}
```

Using `Buffer(...).toString()` to generate a basic auth token, which is the proper way to authenticate using basic authentication (https://swagger.io/docs/specification/authentication/basic-authentication/)

if we are happy with it I can release `primero v2.2.0` in the AM