### PR TITLE
replace Buffer(x) with Buffer.from(x), fixes #22

### DIFF
--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -133,7 +133,7 @@ function generateAuthString(state) {
   if (configuration.basicAuth) {
     var user = configuration.user,
         password = configuration.password;
-    return 'Basic ' + Buffer("".concat(user, ":").concat(password)).toString('base64');
+    return 'Basic ' + Buffer.from("".concat(user, ":").concat(password)).toString('base64');
   }
 
   var token = auth.token;

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -46,7 +46,7 @@ function generateAuthString(state) {
   const { auth, configuration } = state;
   if (configuration.basicAuth) {
     const { user, password } = configuration;
-    return 'Basic ' + Buffer(`${user}:${password}`).toString('base64');
+    return 'Basic ' + Buffer.from(`${user}:${password}`).toString('base64');
   }
   const { token } = auth;
   return `Bearer ${token}`;


### PR DESCRIPTION
This commit fixes #22 . @lakhassane , this needs testing and a new release (ask Stu for release help!) but the resolution was in @aleksa-krolls 's error message: "Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead." I followed those instructions—I chose `Buffer.from(...)` and have verified that the output is the same as `Buffer(x)` but without the warning message.

Please review, merge, and release when you're ready!