### PR TITLE
Concept for scrubbing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An OpenFn **_adaptor_** for building integration jobs for use with UNICEF's Prim
 ## Primero API Versions
 
 ### Adaptor for Primero v2.0
+
 This documentation outlines the functions available for Primero `v2.0` in the main branch. The API documentation is available at: https://github.com/primeroIMS/primero/blob/development_v2/README.md
 
 ### Adaptor for Primero v1.0 still available on the `v1` branch.
@@ -82,7 +83,7 @@ Use this function to insert a new case in Primero based on a set of Data.
 ```js
 createCase(
   {
-    data: state => data {
+    data: state => ({
       remote: true,
       enabled: true,
       age: 15,
@@ -96,7 +97,7 @@ createCase(
         services_section: [ ... ],
         transitions: [ ... ]
       },
-    }
+    })
   }
 );
 ```

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -16,6 +16,12 @@ Object.defineProperty(exports, "alterState", {
     return _languageCommon.alterState;
   }
 });
+Object.defineProperty(exports, "fn", {
+  enumerable: true,
+  get: function get() {
+    return _languageCommon.fn;
+  }
+});
 Object.defineProperty(exports, "combine", {
   enumerable: true,
   get: function get() {
@@ -170,6 +176,7 @@ function login(state) {
   };
   return new Promise(function (resolve, reject) {
     (0, _request["default"])(params, function (error, response, body) {
+      response = (0, _Utils.scrubResponse)(response);
       error = (0, _Utils.assembleError)({
         error: error,
         response: response,
@@ -231,6 +238,7 @@ function getCases(query, callback) {
     };
     return new Promise(function (resolve, reject) {
       (0, _request["default"])(params, function (error, response, body) {
+        response = (0, _Utils.scrubResponse)(response);
         error = (0, _Utils.assembleError)({
           error: error,
           response: response,
@@ -295,6 +303,7 @@ function createCase(params, callback) {
     };
     return new Promise(function (resolve, reject) {
       (0, _request["default"])(requestParams, function (error, response, body) {
+        response = (0, _Utils.scrubResponse)(response);
         error = (0, _Utils.assembleError)({
           error: error,
           response: response,
@@ -356,6 +365,7 @@ function updateCase(id, params, callback) {
     };
     return new Promise(function (resolve, reject) {
       (0, _request["default"])(requestParams, function (error, response, body) {
+        response = (0, _Utils.scrubResponse)(response);
         error = (0, _Utils.assembleError)({
           error: error,
           response: response,
@@ -426,6 +436,7 @@ function upsertCase(params, callback) {
     console.log("Upserting: ".concat(JSON.stringify(requestParams, null, 2)));
     return new Promise(function (resolve, reject) {
       (0, _request["default"])(requestParams, function (error, response, body) {
+        response = (0, _Utils.scrubResponse)(response);
         error = (0, _Utils.assembleError)({
           error: error,
           response: response,
@@ -510,6 +521,7 @@ function getReferrals(recordId, callback) {
     };
     return new Promise(function (resolve, reject) {
       (0, _request["default"])(params, function (error, response, body) {
+        response = (0, _Utils.scrubResponse)(response);
         error = (0, _Utils.assembleError)({
           error: error,
           response: response,
@@ -570,6 +582,7 @@ function createReferrals(params, callback) {
     };
     return new Promise(function (resolve, reject) {
       (0, _request["default"])(requestParams, function (error, response, body) {
+        response = (0, _Utils.scrubResponse)(response);
         error = (0, _Utils.assembleError)({
           error: error,
           response: response,

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -85,7 +85,7 @@ var _request = _interopRequireDefault(require("request"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -8,6 +8,12 @@ exports.setAuth = setAuth;
 exports.assembleError = assembleError;
 exports.tryJson = tryJson;
 
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 function setUrl(configuration, path) {
   console.log(configuration);
   if (configuration && configuration.url) return configuration.url + path;else return path;
@@ -32,7 +38,15 @@ function assembleError(_ref) {
   }
 
   if (error) return error;
-  return new Error("Server responded with:  \n".concat(JSON.stringify(response, null, 2)));
+
+  var safeRequest = _objectSpread({}, response.request, {
+    headers: 'REDACTED',
+    body: 'REDACTED'
+  });
+
+  return new Error("Server responded with:  \n".concat(JSON.stringify(_objectSpread({}, response, {
+    request: safeRequest
+  }), null, 2)));
 }
 
 function tryJson(data) {

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -5,14 +5,9 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.setUrl = setUrl;
 exports.setAuth = setAuth;
+exports.scrubResponse = scrubResponse;
 exports.assembleError = assembleError;
 exports.tryJson = tryJson;
-
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
-
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function setUrl(configuration, path) {
   console.log(configuration);
@@ -27,6 +22,11 @@ function setAuth(configuration, manualAuth) {
   };else return null;
 }
 
+function scrubResponse(response) {
+  response.request.headers.Authorization = '--REDACTED--';
+  return response;
+}
+
 function assembleError(_ref) {
   var response = _ref.response,
       error = _ref.error,
@@ -38,15 +38,7 @@ function assembleError(_ref) {
   }
 
   if (error) return error;
-
-  var safeRequest = _objectSpread({}, response.request, {
-    headers: 'REDACTED',
-    body: 'REDACTED'
-  });
-
-  return new Error("Server responded with:  \n".concat(JSON.stringify(_objectSpread({}, response, {
-    request: safeRequest
-  }), null, 2)));
+  return new Error("Server responded with:\n".concat(JSON.stringify(response, null, 2)));
 }
 
 function tryJson(data) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,9 +11,9 @@ var Adaptor = _interopRequireWildcard(require("./Adaptor"));
 
 exports.Adaptor = Adaptor;
 
-function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 var _default = Adaptor;
 exports["default"] = _default;

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -1,10 +1,10 @@
-/** @module Adaptor */
+// /** @module Adaptor */
 import {
   execute as commonExecute,
   expandReferences,
   composeNextState,
 } from '@openfn/language-common';
-import { assembleError, tryJson } from './Utils';
+import { assembleError, scrubResponse, tryJson } from './Utils';
 import request from 'request';
 
 /**
@@ -80,6 +80,7 @@ function login(state) {
 
   return new Promise((resolve, reject) => {
     request(params, function (error, response, body) {
+      response = scrubResponse(response);
       error = assembleError({ error, response, params });
       if (error) {
         reject(error);
@@ -134,6 +135,7 @@ export function getCases(query, callback) {
 
     return new Promise((resolve, reject) => {
       request(params, function (error, response, body) {
+        response = scrubResponse(response);
         error = assembleError({ error, response, params });
         if (error) {
           reject(error);
@@ -198,6 +200,7 @@ export function createCase(params, callback) {
 
     return new Promise((resolve, reject) => {
       request(requestParams, (error, response, body) => {
+        response = scrubResponse(response);
         error = assembleError({ error, response, params: requestParams });
         if (error) {
           reject(error);
@@ -250,6 +253,7 @@ export function updateCase(id, params, callback) {
 
     return new Promise((resolve, reject) => {
       request(requestParams, (error, response, body) => {
+        response = scrubResponse(response);
         error = assembleError({ error, response, params: {} });
         if (error) {
           reject(error);
@@ -313,6 +317,7 @@ export function upsertCase(params, callback) {
 
     return new Promise((resolve, reject) => {
       request(requestParams, (error, response, body) => {
+        response = scrubResponse(response);
         error = assembleError({ error, response, params: {} });
         if (error) {
           reject(error);
@@ -396,6 +401,7 @@ export function getReferrals(recordId, callback) {
 
     return new Promise((resolve, reject) => {
       request(params, function (error, response, body) {
+        response = scrubResponse(response);
         error = assembleError({ error, response, params });
         if (error) {
           reject(error);
@@ -458,6 +464,7 @@ export function createReferrals(params, callback) {
 
     return new Promise((resolve, reject) => {
       request(requestParams, (error, response, body) => {
+        response = scrubResponse(response);
         error = assembleError({ error, response, params: requestParams });
         if (error) {
           reject(error);

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -28,6 +28,7 @@ export function assembleError({ response, error, params }) {
     if ((customCodes || [200, 201, 202, 204]).indexOf(response.statusCode) > -1)
       return false;
   }
+
   if (error) return error;
 
   return new Error(

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -23,8 +23,19 @@ export function assembleError({ response, error, params }) {
       return false;
   }
   if (error) return error;
+
+  const safeRequest = {
+    ...response.request,
+    headers: 'REDACTED',
+    body: 'REDACTED',
+  };
+
   return new Error(
-    `Server responded with:  \n${JSON.stringify(response, null, 2)}`
+    `Server responded with:  \n${JSON.stringify(
+      { ...response, request: safeRequest },
+      null,
+      2
+    )}`
   );
 }
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -16,6 +16,12 @@ export function setAuth(configuration, manualAuth) {
   else return null;
 }
 
+export function scrubResponse(response) {
+  response.request.headers.Authorization = '--REDACTED--';
+
+  return response;
+}
+
 export function assembleError({ response, error, params }) {
   if (response) {
     const customCodes = params.options && params.options.successCodes;
@@ -24,18 +30,8 @@ export function assembleError({ response, error, params }) {
   }
   if (error) return error;
 
-  const safeRequest = {
-    ...response.request,
-    headers: 'REDACTED',
-    body: 'REDACTED',
-  };
-
   return new Error(
-    `Server responded with:  \n${JSON.stringify(
-      { ...response, request: safeRequest },
-      null,
-      2
-    )}`
+    `Server responded with:\n${JSON.stringify(response, null, 2)}`
   );
 }
 


### PR DESCRIPTION
We need to balance debug-ability with security here. Maybe consider an option for increasing or decreasing the log level?

In essence, it's helpful to see the request when building jobs. Then it's more secure to _not_ see the request even if an error is thrown. @lakhassane , @stuartc , do you have thoughts on this type of error handling? Ideally we would not expose anything from the initial request unless asked for it.

This is just a concept PR for now to get the conversation started. Not wedded to any code in here, and it all needs a more thoughtful look but I'm running out the door right now!

Taylor