### PR TITLE
Rename or fix updateReferrals

### DIFF
--- a/ast.json
+++ b/ast.json
@@ -329,13 +329,13 @@
       "valid": true
     },
     {
-      "name": "updateReferrals",
+      "name": "updateReferral",
       "params": [
         "params",
         "callback"
       ],
       "docs": {
-        "description": "Update referrals for a specific case in Primero",
+        "description": "Update a single referral for a specific case in Primero",
         "tags": [
           {
             "title": "public",
@@ -344,7 +344,7 @@
           },
           {
             "title": "example",
-            "description": "updateReferrals(\n {\n   externalId: \"record_id\",\n   id: \"7ed1d49f-14c7-4181-8d83-dc8ed1699f08\"\n   referral_id: \"37612f65-3bda-48eb-b526-d31383f94166\",\n   data: state => state.data\n },\n callback)"
+            "description": "updateReferral(\n {\n   externalId: \"record_id\",\n   id: \"7ed1d49f-14c7-4181-8d83-dc8ed1699f08\"\n   referral_id: \"37612f65-3bda-48eb-b526-d31383f94166\",\n   data: state => state.data\n },\n callback)"
           },
           {
             "title": "function",

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -11,6 +11,7 @@ exports.upsertCase = upsertCase;
 exports.getReferrals = getReferrals;
 exports.createReferrals = createReferrals;
 exports.updateReferrals = updateReferrals;
+exports.updateReferral = updateReferral;
 Object.defineProperty(exports, "alterState", {
   enumerable: true,
   get: function get() {
@@ -681,12 +682,18 @@ function createReferrals(params, callback) {
       });
     });
   };
+} // TODO: We need to deprecate this.
+
+
+function updateReferrals(params, callback) {
+  console.log('DEPRECATION WARNING: `updateReferrals` is being deprecated and is now called' + ' `updateReferral`; it only allows users to update a single referral on a' + 'single case. Please update your job accordingly.');
+  return updateReferral(params, callback);
 }
 /**
- * Update referrals for a specific case in Primero
+ * Update a single referral for a specific case in Primero
  * @public
  * @example
- * updateReferrals(
+ * updateReferral(
  *  {
  *    externalId: "record_id",
  *    id: "7ed1d49f-14c7-4181-8d83-dc8ed1699f08"
@@ -701,7 +708,7 @@ function createReferrals(params, callback) {
  */
 
 
-function updateReferrals(params, callback) {
+function updateReferral(params, callback) {
   return function (state) {
     var auth = state.auth;
     var url = state.configuration.url;

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -399,13 +399,12 @@ export function upsertCase(params, callback) {
  * Get referrals for a specific case in Primero
  * @public
  * @example
- * getReferrals(
- *  {
- *    externalId: "record_id",
- *    id: "7ed1d49f-14c7-4181-8d83-dc8ed1699f08"
- *  }, callback)
+ * getReferrals({
+ *   externalId: "record_id",
+ *   id: "7ed1d49f-14c7-4181-8d83-dc8ed1699f08"
+ * }, callback)
  * @function
- * @param {object} params - an object with an externalId value to use and the id.
+ * @param {object} params - an object with an externalId field and an externalId value.
  * @param {function} callback - (Optional) Callback function
  * @returns {Operation}
  */
@@ -480,17 +479,18 @@ export function getReferrals(params, callback) {
 }
 
 /**
- * Create case in Primero
+ * Create referrals in Primero
  * @public
  * @example
  * createReferrals({
  *   data: {
- *    "ids": ['case_id'],
- *    "transitioned_to": "primero_cp",
- *    "notes": "Creating a referral"
- *   }}, callback)
+ *     "ids": ['case_id'],
+ *      "transitioned_to": "primero_cp",
+ *      "notes": "Creating a referral"
+ *   }
+ * }, callback)
  * @function
- * @param {object} params - an object with some case data.
+ * @param {object} params - an object with referral data.
  * @param {function} callback - (Optional) Callback function
  * @returns {Operation}
  */
@@ -548,14 +548,12 @@ export function updateReferrals(params, callback) {
  * Update a single referral for a specific case in Primero
  * @public
  * @example
- * updateReferral(
- *  {
- *    externalId: "record_id",
- *    id: "7ed1d49f-14c7-4181-8d83-dc8ed1699f08"
- *    referral_id: "37612f65-3bda-48eb-b526-d31383f94166",
- *    data: state => state.data
- *  },
- *  callback)
+ * updateReferral({
+ *   caseExternalId: "record_id",
+ *   caseId: "7ed1d49f-14c7-4181-8d83-dc8ed1699f08"
+ *   id: "37612f65-3bda-48eb-b526-d31383f94166",
+ *   data: state => state.data
+ * }, callback)
  * @function
  * @param {object} params - an object with an externalId value to use, the id and the referral id to update.
  * @param {function} callback - (Optional) Callback function
@@ -566,16 +564,16 @@ export function updateReferral(params, callback) {
     const { auth } = state;
     const { url } = state.configuration;
 
-    const { externalId, id, referral_id, data } =
+    const { caseExternalId, caseId, id, data } =
       expandReferences(params)(state);
 
     let requestParams = {};
 
-    if (externalId === 'record_id') {
+    if (caseExternalId === 'record_id') {
       console.log('Updating by record id...');
       requestParams = {
         method: 'PATCH',
-        url: `${url}/api/v2/cases/${id}/referrals/${referral_id}`,
+        url: `${url}/api/v2/cases/${caseId}/referrals/${id}`,
         headers: {
           Authorization: auth.token,
           'Content-Type': 'application/json',
@@ -586,7 +584,7 @@ export function updateReferral(params, callback) {
     } else {
       console.log('Updating by case id...');
       const qs = {
-        case_id: `${id}`,
+        case_id: `${caseId}`,
       };
       requestParams = {
         method: 'GET',
@@ -612,10 +610,10 @@ export function updateReferral(params, callback) {
             } else if (resp.data.length === 1) {
               console.log('Case found. Fetching referrals.');
 
-              const id = resp.data[0].id;
+              const caseRecordId = resp.data[0].id;
               requestParams = {
                 method: 'PATCH',
-                url: `${url}/api/v2/cases/${id}/referrals/${referral_id}`,
+                url: `${url}/api/v2/cases/${caseRecordId}/referrals/${id}`,
 
                 headers: {
                   Authorization: auth.token,

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -534,11 +534,21 @@ export function createReferrals(params, callback) {
   };
 }
 
+// TODO: We need to deprecate this.
+export function updateReferrals(params, callback) {
+  console.log(
+    'DEPRECATION WARNING: `updateReferrals` is being deprecated and is now called' +
+      ' `updateReferral`; it only allows users to update a single referral on a' +
+      'single case. Please update your job accordingly.'
+  );
+  return updateReferral(params, callback);
+}
+
 /**
- * Update referrals for a specific case in Primero
+ * Update a single referral for a specific case in Primero
  * @public
  * @example
- * updateReferrals(
+ * updateReferral(
  *  {
  *    externalId: "record_id",
  *    id: "7ed1d49f-14c7-4181-8d83-dc8ed1699f08"
@@ -551,7 +561,7 @@ export function createReferrals(params, callback) {
  * @param {function} callback - (Optional) Callback function
  * @returns {Operation}
  */
-export function updateReferrals(params, callback) {
+export function updateReferral(params, callback) {
   return state => {
     const { auth } = state;
     const { url } = state.configuration;


### PR DESCRIPTION
@lakhassane , @aleksa-krolls , @daissatou2 , please see my suggested change here. It looks like there's no way to update multiple referrals (I could be wrong here!) but we've got a function in the adaptor called `updateReferrals`. This just through me for quite a loop, and I'd suggest that we either:

- (a) provide an interface to update multiple referrals
- or (b) rename this function to indicate that it allows you to update only a single referral.

I don't know if there's demand for (a) from Primero users, so this PR implements (b). Can I get your thoughts?