### PR TITLE
Support query lookups in the primero adaptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,25 @@ getForms(
 );
 ```
 
+### Get lookups from Primero with query parameters
+
+Use this function to get a paginated list of all lookups that are accessible to this user from Primero.
+
+Note: You can specify a `per` value to fetch records per page(Defaults to 20). Also you can specify `page` value to fetch pagination (Defaults to 1)
+
+```js
+getLookups(
+  {
+    per: 10000,
+    page: 1,
+  },
+  state => {
+    console.log('Here is the callback.');
+    return state;
+  }
+);
+```
+
 ### Create a new case in Primero
 
 Use this function to insert a new case in Primero based on a set of Data.

--- a/ast.json
+++ b/ast.json
@@ -443,6 +443,59 @@
         ]
       },
       "valid": true
+    },
+    {
+      "name": "getLookups",
+      "params": [
+        "query",
+        "callback"
+      ],
+      "docs": {
+        "description": "Get lookups from Primero",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "getLookups({\n  page: 1 // Optional. Pagination. Defaults to 1,\n  per: 20 // Optional. Records per page. Defaults to 20,\n}, callback)"
+          },
+          {
+            "title": "function",
+            "description": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "an object with a query param at minimum",
+            "type": {
+              "type": "NameExpression",
+              "name": "object"
+            },
+            "name": "query"
+          },
+          {
+            "title": "param",
+            "description": "(Optional) Callback function",
+            "type": {
+              "type": "NameExpression",
+              "name": "function"
+            },
+            "name": "callback"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": true
     }
   ],
   "exports": [],

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -13,6 +13,7 @@ exports.createReferrals = createReferrals;
 exports.updateReferrals = updateReferrals;
 exports.updateReferral = updateReferral;
 exports.getForms = getForms;
+exports.getLookups = getLookups;
 Object.defineProperty(exports, "alterState", {
   enumerable: true,
   get: function () {
@@ -883,6 +884,63 @@ function getForms(query, callback) {
           const forms = resp.data;
           console.log(`${forms.length} forms retrieved from request: ${JSON.stringify(response.request, null, 2)}`);
           const nextState = (0, _languageCommon.composeNextState)(state, forms);
+          if (callback) resolve(callback(nextState));
+          resolve(nextState);
+        }
+      });
+    });
+  };
+}
+/**
+ * Get lookups from Primero
+ * @public
+ * @example
+ * getLookups({
+ *   page: 1 // Optional. Pagination. Defaults to 1,
+ *   per: 20 // Optional. Records per page. Defaults to 20,
+ * }, callback)
+ * @function
+ * @param {object} query - an object with a query param at minimum
+ * @param {function} callback - (Optional) Callback function
+ * @returns {Operation}
+ */
+
+
+function getLookups(query, callback) {
+  return state => {
+    const {
+      auth
+    } = state;
+    const {
+      url
+    } = state.configuration;
+    const expandedQuery = (0, _languageCommon.expandReferences)(query)(state);
+    const params = {
+      method: 'GET',
+      url: `${url}/api/v2/lookups`,
+      headers: {
+        Authorization: auth.token,
+        'Content-Type': 'application/json'
+      },
+      qs: expandedQuery
+    };
+    return new Promise((resolve, reject) => {
+      (0, _request.default)(params, async function (error, response, body) {
+        response = (0, _Utils.scrubResponse)(response);
+        error = (0, _Utils.assembleError)({
+          error,
+          response,
+          params
+        });
+
+        if (error) {
+          reject(error);
+        } else {
+          console.log(`Primero says: '${response.statusCode} ${response.statusMessage}'`);
+          const resp = (0, _Utils.tryJson)(body);
+          const lookups = resp.data;
+          console.log(`${lookups.length} lookups retrieved from request: ${JSON.stringify(response.request, null, 2)}`);
+          const nextState = (0, _languageCommon.composeNextState)(state, lookups);
           if (callback) resolve(callback(nextState));
           resolve(nextState);
         }


### PR DESCRIPTION
## Any notes for the reviewer ?
Add `getLookups` helper function which fetches a paginated list of all lookups of the authorized user
## Related issue
Fixes #42
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my code
- [x] I have updated read me